### PR TITLE
Add user click prevention feature

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -30,7 +30,9 @@ class Game {
     }
 
     resetBoard(characters) {
+        characterOptions.removeEventListener('click', characterChoice);
         setTimeout(() => {loadCharacters(characters)}, 2000);
+        setTimeout(() => {characterOptions.addEventListener('click', characterChoice)}, 2000);
         this.updateScores();
     }
 


### PR DESCRIPTION
# Description
Added a small feature that prevents the user from choosing another character while the 'battle cutscene' is occurring. This helps maintain usability and from other events stacking on each other.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring

# How Has This Been Tested?
- [x] open localHost
- [x] dev tools

# Checklist:
- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages